### PR TITLE
Add the timezone flag to docker with LA timezone

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -6,7 +6,7 @@ build:
 	docker build -t mesa-backend .
 
 run:
-	docker run -t -i -p 5000:5000  -p 80:80 --rm mesa-backend
+	docker run -e TZ=America/Los_Angeles -t -i -p 5000:5000  -p 80:80 --rm mesa-backend
 
 test:
 	python3 ./test/request_server.py


### PR DESCRIPTION
The timezone was not setup correctly for docker, as a result we did not return upcoming events in the write way. 