### PR TITLE
Update the UI it will now present related upcoming events

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,9 @@ COPY ./requirements.txt /backend/requirements.txt
 WORKDIR /backend
 RUN pip install -r requirements.txt
 
+ENV TZ=America/Los_Angeles
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 FROM dependencies
 ADD ./server/ /backend
 ENTRYPOINT ["./server_setup_entrypoint"]

--- a/backend/server/data_collection/web_scraper.py
+++ b/backend/server/data_collection/web_scraper.py
@@ -56,15 +56,21 @@ def get_upcoming_events(label, number_of_events=2) -> list:
         # logger.warning(tuple(row))
         if row["dayOfWeek"] == today_day:
             time = to_datetime(row)
-            events_today.append(row[:4] + (time,))
+            events_today.append({
+                    "name": row["name"],
+                    "time": time,
+                    "label": row["label"],
+                    "location": row["location"],
+                    "dayOfWeek": row["dayOfWeek"],
+                })
 
     # Filter out events happening after now
     def now_or_later(event) -> bool:
-        return event[4] > now
+        return event["time"] > now
     events_today = list(filter(now_or_later, events_today))
 
     # Sort events by time
-    events_today.sort(key=lambda x: x[4])
+    events_today.sort(key=lambda x: x["time"])
 
     logger.debug("Events today after now sorted: " + repr(events_today))
 

--- a/backend/server/data_collection/web_scraper.py
+++ b/backend/server/data_collection/web_scraper.py
@@ -88,10 +88,10 @@ def eventsToDb():
     now = datetime.datetime.today()
     today_day = now.strftime("%A")
 
-    # global classes_list
-    # if classes_list is None:
-    #     classes_list = scrape_arc.scrapeARC()
-    #     __commit_data_db(today_day, classes_list, "workout", location="ARC")
+    global classes_list
+    if classes_list is None:
+        classes_list = scrape_arc.scrapeARC()
+        __commit_data_db(today_day, classes_list, "workout", location="ARC")
 
     global event_list
     if event_list is None:

--- a/mesa/App.js
+++ b/mesa/App.js
@@ -18,7 +18,7 @@ export default class App extends React.Component {
 
 				<Greeter/>
 				
-				<Card title="n Tasks" containerStyle={{
+				<Card title="Tasks" containerStyle={{
 					flex: 0.7,
 					marginBottom: 30,
 				}}>

--- a/mesa/src/components/event_component.js
+++ b/mesa/src/components/event_component.js
@@ -5,7 +5,6 @@ export class Event extends Component {
 
     constructor(props){
         super(props);
-        console.log(this.props);
     }
 
     viewDescription() {

--- a/mesa/src/components/event_component.js
+++ b/mesa/src/components/event_component.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { StyleSheet, Text } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, Alert } from 'react-native';
 
 export class Event extends Component {
 
@@ -8,15 +8,31 @@ export class Event extends Component {
         console.log(this.props);
     }
 
+    viewDescription() {
+        let name = this.props.event[0].name
+        let time = this.props.event[0].time;
+        let location = this.props.event[0].location;
+        let description = `Time: ${time} Location: ${location}`;
+        let title = `Event: ${name}`;
+        Alert.alert(
+            title,
+            description,
+            [
+                { text: 'OK', onPress: () => console.log('OK Pressed') },
+            ],
+            { cancelable: false },
+        );
+    }
+
     render() {
         if (this.props.event.length == 0) {
             return null;
         }
         else {
-            console.log("Event data:")
-            console.log(this.props.event)
             return (
-                <Text> Related Upcoming Event: {this.props.event[0][2]} </Text>
+                <TouchableOpacity onPress={() => { this.viewDescription() }}>
+                    <Text> Related Upcoming Event: {this.props.event[0].name} </Text>
+                </TouchableOpacity>
             );
         }
     }

--- a/mesa/src/components/event_component.js
+++ b/mesa/src/components/event_component.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+import { StyleSheet, Text } from 'react-native';
+
+export class Event extends Component {
+
+    constructor(props){
+        super(props);
+        console.log(this.props);
+    }
+
+    render() {
+        if (this.props.event.length == 0) {
+            return null;
+        }
+        else {
+            console.log("Event data:")
+            console.log(this.props.event)
+            return (
+                <Text> Related Upcoming Event: {this.props.event[0][2]} </Text>
+            );
+        }
+    }
+}
+
+
+const styles = StyleSheet.create({
+    taskitem: {
+        flexDirection: "row",
+        paddingTop: 10,
+        paddingBottom: 10,
+    },
+});

--- a/mesa/src/components/greeter.js
+++ b/mesa/src/components/greeter.js
@@ -12,8 +12,8 @@ export class Greeter extends Component {
         <Text style={styles.pYellow}>How are you feeling?</Text>
         <Weather style={styles.p} />
         <ActivityComponent style={styles.p} />
-        <Text style={styles.p}>You have N tasks left to do today.</Text>
-        <Text style={styles.p}>There are M events coming up.</Text>
+        {/* <Text style={styles.p}>You have N tasks left to do today.</Text> */}
+        {/* <Text style={styles.p}>There are M events coming up.</Text> */}
         <Text style={[styles.p, {marginTop: "auto"}]}>TODAY : {new Date().toDateString()}</Text>
         <MoodSurvey style={styles.welcome}/>
         </View>

--- a/mesa/src/components/task.js
+++ b/mesa/src/components/task.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
-import { StyleSheet, Text, View, Button, TouchableOpacity, Modal, Alert } from 'react-native';
+import { StyleSheet, Text, View, Button, TouchableOpacity, Alert } from 'react-native';
+import { Event } from './event_component';
 
 export class Task extends Component {
     completeTask() {
@@ -41,8 +42,8 @@ export class Task extends Component {
 
     viewDescription() {
       Alert.alert(
-        this.props.name,
-        this.props.description,
+        this.props.task.name,
+        this.props.task.description,
         [
           {
             text: 'Cancel',
@@ -57,20 +58,19 @@ export class Task extends Component {
 
     render() {
         return (
+          <View>
           <View style={styles.taskitem}>
             <View style={{flex: 1, justifyContent: "center", alignItems: "center"}}>
               <TouchableOpacity onPress={ () => { this.viewDescription() } }>
-                <Text>{this.props.name}</Text>
+                <Text>{this.props.task.name}</Text>
               </TouchableOpacity>
+              <Event event={this.props.task.event_data} />
             </View>
-            <View style={{flex: 1}}>
-              <Button
-                  onPress={ () => { this.completeTask() } }
-                  title="Complete Task"
-                  color="#ffd200"
-                  accessibilityLabel="Click here to complete the task."
-                />
-            </View>
+
+          </View>
+
+          
+            <Button onPress={() => { this.completeTask() }} title="Complete Task" color="#ffd200" accessibilityLabel="Click here to complete the task."/>
           </View>
         );
     }

--- a/mesa/src/components/task.js
+++ b/mesa/src/components/task.js
@@ -45,11 +45,6 @@ export class Task extends Component {
         this.props.task.name,
         this.props.task.description,
         [
-          {
-            text: 'Cancel',
-            onPress: () => console.log('Cancel Pressed'),
-            style: 'cancel',
-          },
           {text: 'OK', onPress: () => console.log('OK Pressed')},
         ],
         {cancelable: false},

--- a/mesa/src/components/task_list.js
+++ b/mesa/src/components/task_list.js
@@ -9,9 +9,9 @@ export class TaskList extends Component {
         super(props);
 
         this.state = {
-            task1: { name: "task_1" },
-            task2: { name: "task_2" },
-            task3: { name: "task_3" }
+            task1: { name: "task_1", description:"", event_data:[]},
+            task2: { name: "task_2", description:"", event_data:[]},
+            task3: { name: "task_3", description:"", event_data:[]}
         };
 
         personalModel.register(this);
@@ -69,9 +69,9 @@ export class TaskList extends Component {
     render() {
         return (
             <ScrollView style={{ marginBottom: 60 }} > 
-                <Task name={this.state.task1.name} description={this.state.task1.description} />
-                <Task name={this.state.task2.name} description={this.state.task2.description} />
-                <Task name={this.state.task3.name} description={this.state.task3.description} />
+                <Task task={this.state.task1} />
+                <Task task={this.state.task2} />
+                <Task task={this.state.task3} />
             </ScrollView>
         );
     }

--- a/mesa/src/components/task_list.js
+++ b/mesa/src/components/task_list.js
@@ -67,6 +67,7 @@ export class TaskList extends Component {
     }
 
     render() {
+        console.log(this.state);
         return (
             <ScrollView style={{ marginBottom: 60 }} > 
                 <Task task={this.state.task1} />


### PR DESCRIPTION
UI will present related upcoming events, but leaves a lot of information out at the moment. We will need to figure out what a better way would be to present the data on the screen. 

Information left out:
1. Time of event
2. Location of event

Also some events can be presented twice, maybe the "nicer" way of doing it is creating a second screen or display the events separetly not under the task. I think we can just merge it and say in the demo that how to present the data is still a WIP? 

When merged we could close  #35.

Opinions/Feedback @TDHTTTT @jessechong @mmarano25?